### PR TITLE
Add unit tests for ygodb helpers and CLI mode parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func atoMode(s string) mode {
 	return modeUnknown
 }
 
-func init() {
+func main() {
 	m := flag.String("mode", fmt.Sprint(modeSelect), fmt.Sprintf("Specifies the behavior of this code. [%s]", strings.Join(modes(), "|")))
 	l := flag.String("lang", string(ygodb.LangJA), "Language for selecting from the DB.")
 	c := flag.String("name", "", "The card name you want to select.")
@@ -88,9 +88,7 @@ func init() {
 		cardName:    *c,
 		file:        *f,
 	}
-}
 
-func main() {
 	switch opt.executeMode {
 	case modeSelect:
 		for _, v := range selectCard(opt.cardName, opt.lang) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kotaoue/ygoc/packages/ygodb"
+)
+
+func Test_mode_String(t *testing.T) {
+	tests := []struct {
+		m    mode
+		want string
+	}{
+		{modeUnknown, "unknown"},
+		{modeHelp, "help"},
+		{modeSelect, "select"},
+		{modeLink, "link"},
+		{modeMarkDown, "markdown"},
+		{mode(999), ""},
+	}
+	for _, tt := range tests {
+		r := tt.m.String()
+		if r != tt.want {
+			t.Errorf("mode(%d).String() got %q, want %q", tt.m, r, tt.want)
+		}
+	}
+}
+
+func Test_atoMode(t *testing.T) {
+	tests := []struct {
+		s    string
+		want mode
+	}{
+		{"unknown", modeUnknown},
+		{"help", modeHelp},
+		{"select", modeSelect},
+		{"link", modeLink},
+		{"markdown", modeMarkDown},
+		{"HELP", modeHelp},
+		{"nonexistent", modeUnknown},
+	}
+	for _, tt := range tests {
+		r := atoMode(tt.s)
+		if r != tt.want {
+			t.Errorf("atoMode(%q) got %v, want %v", tt.s, r, tt.want)
+		}
+	}
+}
+
+func Test_modes(t *testing.T) {
+	r := modes()
+	if len(r) == 0 {
+		t.Fatal("modes() returned empty slice")
+	}
+	for _, v := range r {
+		if v == modeUnknown.String() {
+			t.Errorf("modes() contains unknown: %v", r)
+		}
+	}
+}
+
+func Test_linkMD(t *testing.T) {
+	c := ygodb.Card{ID: "4007", Name: "Blue-Eyes White Dragon"}
+	r := linkMD(c)
+	e := "[Blue-Eyes White Dragon](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007)"
+	if r != e {
+		t.Fatalf("linkMD got %q, want %q", r, e)
+	}
+}
+
+func Test_isPrettyTarget(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"- Blue-Eyes White Dragon", true},
+		{"* Blue-Eyes White Dragon", true},
+		{"- [x] Blue-Eyes White Dragon", true},
+		{"- [Dragon](https://example.com/)", false},
+		{"Blue-Eyes White Dragon", false},
+		{"# Heading", false},
+	}
+	for _, tt := range tests {
+		r := isPrettyTarget(tt.s)
+		if r != tt.want {
+			t.Errorf("isPrettyTarget(%q) got %v, want %v", tt.s, r, tt.want)
+		}
+	}
+}
+
+func Test_prettyList_file_not_found(t *testing.T) {
+	r := prettyList("/nonexistent/file.md", ygodb.LangEN)
+	if len(r) != 0 {
+		t.Errorf("expected empty slice, got %v", r)
+	}
+}
+
+func Test_prettyList_non_list_content(t *testing.T) {
+	f, err := os.CreateTemp("", "ygoc_test_*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+
+	content := "# Heading\nPlain text\n[Link](https://example.com/)"
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	r := prettyList(f.Name(), ygodb.LangEN)
+	if len(r) != 3 {
+		t.Errorf("prettyList got %d lines, want 3", len(r))
+	}
+	if len(r) > 0 && r[0] != "# Heading" {
+		t.Errorf("line 0: got %q, want %q", r[0], "# Heading")
+	}
+}
+
+func Test_help(t *testing.T) {
+	help()
+}

--- a/main_test.go
+++ b/main_test.go
@@ -9,42 +9,48 @@ import (
 
 func Test_mode_String(t *testing.T) {
 	tests := []struct {
+		name string
 		m    mode
 		want string
 	}{
-		{modeUnknown, "unknown"},
-		{modeHelp, "help"},
-		{modeSelect, "select"},
-		{modeLink, "link"},
-		{modeMarkDown, "markdown"},
-		{mode(999), ""},
+		{"unknown", modeUnknown, "unknown"},
+		{"help", modeHelp, "help"},
+		{"select", modeSelect, "select"},
+		{"link", modeLink, "link"},
+		{"markdown", modeMarkDown, "markdown"},
+		{"invalid", mode(999), ""},
 	}
 	for _, tt := range tests {
-		r := tt.m.String()
-		if r != tt.want {
-			t.Errorf("mode(%d).String() got %q, want %q", tt.m, r, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.m.String()
+			if r != tt.want {
+				t.Errorf("mode(%d).String() got %q, want %q", tt.m, r, tt.want)
+			}
+		})
 	}
 }
 
 func Test_atoMode(t *testing.T) {
 	tests := []struct {
+		name string
 		s    string
 		want mode
 	}{
-		{"unknown", modeUnknown},
-		{"help", modeHelp},
-		{"select", modeSelect},
-		{"link", modeLink},
-		{"markdown", modeMarkDown},
-		{"HELP", modeHelp},
-		{"nonexistent", modeUnknown},
+		{"unknown", "unknown", modeUnknown},
+		{"help", "help", modeHelp},
+		{"select", "select", modeSelect},
+		{"link", "link", modeLink},
+		{"markdown", "markdown", modeMarkDown},
+		{"upper-help", "HELP", modeHelp},
+		{"invalid", "nonexistent", modeUnknown},
 	}
 	for _, tt := range tests {
-		r := atoMode(tt.s)
-		if r != tt.want {
-			t.Errorf("atoMode(%q) got %v, want %v", tt.s, r, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r := atoMode(tt.s)
+			if r != tt.want {
+				t.Errorf("atoMode(%q) got %v, want %v", tt.s, r, tt.want)
+			}
+		})
 	}
 }
 
@@ -61,42 +67,57 @@ func Test_modes(t *testing.T) {
 }
 
 func Test_linkMD(t *testing.T) {
-	c := ygodb.Card{ID: "4007", Name: "Blue-Eyes White Dragon"}
-	r := linkMD(c)
-	e := "[Blue-Eyes White Dragon](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007)"
-	if r != e {
-		t.Fatalf("linkMD got %q, want %q", r, e)
+	tests := []struct {
+		name string
+		card ygodb.Card
+		want string
+	}{
+		{
+			name: "normal",
+			card: ygodb.Card{ID: "4007", Name: "Blue-Eyes White Dragon"},
+			want: "[Blue-Eyes White Dragon](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007)",
+		},
+		{
+			name: "empty-fields",
+			card: ygodb.Card{},
+			want: "[](https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := linkMD(tt.card)
+			if r != tt.want {
+				t.Fatalf("linkMD got %q, want %q", r, tt.want)
+			}
+		})
 	}
 }
 
 func Test_isPrettyTarget(t *testing.T) {
 	tests := []struct {
+		name string
 		s    string
 		want bool
 	}{
-		{"- Blue-Eyes White Dragon", true},
-		{"* Blue-Eyes White Dragon", true},
-		{"- [x] Blue-Eyes White Dragon", true},
-		{"- [Dragon](https://example.com/)", false},
-		{"Blue-Eyes White Dragon", false},
-		{"# Heading", false},
+		{"dash-list", "- Blue-Eyes White Dragon", true},
+		{"asterisk-list", "* Blue-Eyes White Dragon", true},
+		{"checkbox-list", "- [x] Blue-Eyes White Dragon", true},
+		{"already-linked", "- [Dragon](https://example.com/)", false},
+		{"plain", "Blue-Eyes White Dragon", false},
+		{"heading", "# Heading", false},
 	}
 	for _, tt := range tests {
-		r := isPrettyTarget(tt.s)
-		if r != tt.want {
-			t.Errorf("isPrettyTarget(%q) got %v, want %v", tt.s, r, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r := isPrettyTarget(tt.s)
+			if r != tt.want {
+				t.Errorf("isPrettyTarget(%q) got %v, want %v", tt.s, r, tt.want)
+			}
+		})
 	}
 }
 
-func Test_prettyList_file_not_found(t *testing.T) {
-	r := prettyList("/nonexistent/file.md", ygodb.LangEN)
-	if len(r) != 0 {
-		t.Errorf("expected empty slice, got %v", r)
-	}
-}
-
-func Test_prettyList_non_list_content(t *testing.T) {
+func Test_prettyList(t *testing.T) {
 	f, err := os.CreateTemp("", "ygoc_test_*.md")
 	if err != nil {
 		t.Fatal(err)
@@ -109,12 +130,26 @@ func Test_prettyList_non_list_content(t *testing.T) {
 	}
 	f.Close()
 
-	r := prettyList(f.Name(), ygodb.LangEN)
-	if len(r) != 3 {
-		t.Errorf("prettyList got %d lines, want 3", len(r))
+	tests := []struct {
+		name     string
+		fileName string
+		wantLen  int
+		wantHead string
+	}{
+		{"file-not-found", "/nonexistent/file.md", 0, ""},
+		{"non-list-content", f.Name(), 3, "# Heading"},
 	}
-	if len(r) > 0 && r[0] != "# Heading" {
-		t.Errorf("line 0: got %q, want %q", r[0], "# Heading")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := prettyList(tt.fileName, ygodb.LangEN)
+			if len(r) != tt.wantLen {
+				t.Errorf("prettyList got %d lines, want %d", len(r), tt.wantLen)
+			}
+			if tt.wantLen > 0 && len(r) > 0 && r[0] != tt.wantHead {
+				t.Errorf("line 0: got %q, want %q", r[0], tt.wantHead)
+			}
+		})
 	}
 }
 

--- a/packages/ygodb/ygodb_internal_test.go
+++ b/packages/ygodb/ygodb_internal_test.go
@@ -1,0 +1,107 @@
+package ygodb
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func newSelection(t *testing.T, html string) *goquery.Selection {
+	t.Helper()
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("failed to parse html: %v", err)
+	}
+	return doc.Find("div.root")
+}
+
+func Test_extractID_from_link_value(t *testing.T) {
+	html := `<div class="root">
+		<input class="link_value" value="https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007" />
+	</div>`
+	s := newSelection(t, html)
+	got := extractID(s)
+	if got != "4007" {
+		t.Errorf("extractID from link_value: got %q, want %q", got, "4007")
+	}
+}
+
+func Test_extractID_fallback_to_cid(t *testing.T) {
+	// link_value exists but value does not contain cid=, so fall back to input.cid
+	html := `<div class="root">
+		<input class="link_value" value="https://example.com/page?ope=1" />
+		<input class="cid" value="9999" />
+	</div>`
+	s := newSelection(t, html)
+	got := extractID(s)
+	if got != "9999" {
+		t.Errorf("extractID fallback to cid: got %q, want %q", got, "9999")
+	}
+}
+
+func Test_extractID_empty(t *testing.T) {
+	// No link_value, no cid inputs
+	html := `<div class="root"></div>`
+	s := newSelection(t, html)
+	got := extractID(s)
+	if got != "" {
+		t.Errorf("extractID empty: got %q, want %q", got, "")
+	}
+}
+
+func Test_extractLimited_from_img_alt(t *testing.T) {
+	html := `<div class="root">
+		<dd class="remove_btn"><a><img alt="Forbidden" /></a></dd>
+	</div>`
+	s := newSelection(t, html)
+	got := extractLimited(s)
+	if got != "Forbidden" {
+		t.Errorf("extractLimited from img alt: got %q, want %q", got, "Forbidden")
+	}
+}
+
+func Test_extractLimited_from_p(t *testing.T) {
+	// No img alt; div.lr_icon p has text
+	html := `<div class="root">
+		<div class="lr_icon"><p>Limited</p></div>
+	</div>`
+	s := newSelection(t, html)
+	got := extractLimited(s)
+	if got != "Limited" {
+		t.Errorf("extractLimited from p: got %q, want %q", got, "Limited")
+	}
+}
+
+func Test_extractLimited_from_span(t *testing.T) {
+	// No img alt, empty p; div.lr_icon span has text
+	html := `<div class="root">
+		<div class="lr_icon"><p></p><span>Semi-Limited</span></div>
+	</div>`
+	s := newSelection(t, html)
+	got := extractLimited(s)
+	if got != "Semi-Limited" {
+		t.Errorf("extractLimited from span: got %q, want %q", got, "Semi-Limited")
+	}
+}
+
+func Test_siteURL(t *testing.T) {
+	got := siteURL()
+	want := "https://www.db.yugioh-card.com"
+	if got != want {
+		t.Errorf("siteURL() = %q, want %q", got, want)
+	}
+}
+
+func Test_apiURL(t *testing.T) {
+	got := apiURL("test", LangEN)
+	if !strings.Contains(got, "https://www.db.yugioh-card.com") {
+		t.Errorf("apiURL() should contain site URL, got %q", got)
+	}
+	if !strings.Contains(got, "keyword=test") {
+		t.Errorf("apiURL() should contain keyword, got %q", got)
+	}
+	if !strings.Contains(got, "request_locale=en") {
+		t.Errorf("apiURL() should contain locale, got %q", got)
+	}
+}

--- a/packages/ygodb/ygodb_internal_test.go
+++ b/packages/ygodb/ygodb_internal_test.go
@@ -16,80 +16,100 @@ func newSelection(t *testing.T, html string) *goquery.Selection {
 	return doc.Find("div.root")
 }
 
-func Test_extractID_from_link_value(t *testing.T) {
-	html := `<div class="root">
-		<input class="link_value" value="https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007" />
-	</div>`
-	s := newSelection(t, html)
-	got := extractID(s)
-	if got != "4007" {
-		t.Errorf("extractID from link_value: got %q, want %q", got, "4007")
+func Test_extractID(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "from-link-value",
+			html: `<div class="root">
+				<input class="link_value" value="https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4007" />
+			</div>`,
+			want: "4007",
+		},
+		{
+			name: "fallback-to-cid",
+			html: `<div class="root">
+				<input class="link_value" value="https://example.com/page?ope=1" />
+				<input class="cid" value="9999" />
+			</div>`,
+			want: "9999",
+		},
+		{
+			name: "empty",
+			html: `<div class="root"></div>`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSelection(t, tt.html)
+			got := extractID(s)
+			if got != tt.want {
+				t.Errorf("extractID() got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
-func Test_extractID_fallback_to_cid(t *testing.T) {
-	// link_value exists but value does not contain cid=, so fall back to input.cid
-	html := `<div class="root">
-		<input class="link_value" value="https://example.com/page?ope=1" />
-		<input class="cid" value="9999" />
-	</div>`
-	s := newSelection(t, html)
-	got := extractID(s)
-	if got != "9999" {
-		t.Errorf("extractID fallback to cid: got %q, want %q", got, "9999")
+func Test_extractLimited(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "from-img-alt",
+			html: `<div class="root">
+				<dd class="remove_btn"><a><img alt="Forbidden" /></a></dd>
+			</div>`,
+			want: "Forbidden",
+		},
+		{
+			name: "from-p",
+			html: `<div class="root">
+				<div class="lr_icon"><p>Limited</p></div>
+			</div>`,
+			want: "Limited",
+		},
+		{
+			name: "from-span",
+			html: `<div class="root">
+				<div class="lr_icon"><p></p><span>Semi-Limited</span></div>
+			</div>`,
+			want: "Semi-Limited",
+		},
 	}
-}
 
-func Test_extractID_empty(t *testing.T) {
-	// No link_value, no cid inputs
-	html := `<div class="root"></div>`
-	s := newSelection(t, html)
-	got := extractID(s)
-	if got != "" {
-		t.Errorf("extractID empty: got %q, want %q", got, "")
-	}
-}
-
-func Test_extractLimited_from_img_alt(t *testing.T) {
-	html := `<div class="root">
-		<dd class="remove_btn"><a><img alt="Forbidden" /></a></dd>
-	</div>`
-	s := newSelection(t, html)
-	got := extractLimited(s)
-	if got != "Forbidden" {
-		t.Errorf("extractLimited from img alt: got %q, want %q", got, "Forbidden")
-	}
-}
-
-func Test_extractLimited_from_p(t *testing.T) {
-	// No img alt; div.lr_icon p has text
-	html := `<div class="root">
-		<div class="lr_icon"><p>Limited</p></div>
-	</div>`
-	s := newSelection(t, html)
-	got := extractLimited(s)
-	if got != "Limited" {
-		t.Errorf("extractLimited from p: got %q, want %q", got, "Limited")
-	}
-}
-
-func Test_extractLimited_from_span(t *testing.T) {
-	// No img alt, empty p; div.lr_icon span has text
-	html := `<div class="root">
-		<div class="lr_icon"><p></p><span>Semi-Limited</span></div>
-	</div>`
-	s := newSelection(t, html)
-	got := extractLimited(s)
-	if got != "Semi-Limited" {
-		t.Errorf("extractLimited from span: got %q, want %q", got, "Semi-Limited")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newSelection(t, tt.html)
+			got := extractLimited(s)
+			if got != tt.want {
+				t.Errorf("extractLimited() got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
 func Test_siteURL(t *testing.T) {
-	got := siteURL()
-	want := "https://www.db.yugioh-card.com"
-	if got != want {
-		t.Errorf("siteURL() = %q, want %q", got, want)
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"default", "https://www.db.yugioh-card.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := siteURL()
+			if got != tt.want {
+				t.Errorf("siteURL() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/packages/ygodb/ygodb_test.go
+++ b/packages/ygodb/ygodb_test.go
@@ -7,104 +7,160 @@ import (
 )
 
 func Test_Card_URL(t *testing.T) {
-	c := ygodb.Card{ID: "123456789"}
-	r := c.URL()
-	e := "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=123456789"
-	if r != e {
-		t.Fatalf("when Card.ID %s, returned %s, expected %s", c.ID, r, e)
+	tests := []struct {
+		name string
+		card ygodb.Card
+		want string
+	}{
+		{
+			name: "normal",
+			card: ygodb.Card{ID: "123456789"},
+			want: "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=123456789",
+		},
+		{
+			name: "empty-id",
+			card: ygodb.Card{},
+			want: "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.card.URL()
+			if r != tt.want {
+				t.Fatalf("when Card.ID %s, returned %s, expected %s", tt.card.ID, r, tt.want)
+			}
+		})
 	}
 }
 
 func Test_Scraping(t *testing.T) {
 	// 外部API依存のテスト - APIの変更やネットワーク問題で失敗する可能性がある
-	k := "Blue-Eyes White Dragon"
-	r, err := ygodb.Scraping(k, ygodb.LangEN)
-	e := ygodb.Card{
-		ID:        "4007",
-		Name:      "Blue-Eyes White Dragon",
-		Limited:   "",
-		Attribute: "LIGHT",
-		Effect:    "",
-		Level:     "Level 8",
-		Link:      "",
-		Attack:    "ATK 3000",
-		Defense:   "DEF 2500",
-		Text:      "This legendary dragon is a powerful engine of destruction. Virtually invincible, very few have faced this awesome creature and lived to tell the tale.",
-	}
-	// FIXME: Revert to t.Fatalf once the external API becomes stable.
-	if err != nil {
-		t.Skipf("when keyword %s error occurred %s\n", k, err.Error())
-	}
-	if r != e {
-		t.Fatalf("when keyword %s\nreturned %#v\nexpected %#v", k, r, e)
+	tests := []struct {
+		name       string
+		keyword    string
+		wantCard   ygodb.Card
+		wantErr    string
+		errStrict  bool
+		allowNoErr bool
+	}{
+		{
+			name:    "blue-eyes",
+			keyword: "Blue-Eyes White Dragon",
+			wantCard: ygodb.Card{
+				ID:        "4007",
+				Name:      "Blue-Eyes White Dragon",
+				Limited:   "",
+				Attribute: "LIGHT",
+				Effect:    "",
+				Level:     "Level 8",
+				Link:      "",
+				Attack:    "ATK 3000",
+				Defense:   "DEF 2500",
+				Text:      "This legendary dragon is a powerful engine of destruction. Virtually invincible, very few have faced this awesome creature and lived to tell the tale.",
+			},
+		},
+		{
+			name:    "raigeki",
+			keyword: "Raigeki",
+			wantCard: ygodb.Card{
+				ID:        "4343",
+				Name:      "Raigeki",
+				Limited:   "",
+				Attribute: "SPELL",
+				Text:      "Destroy all monsters your opponent controls.",
+			},
+		},
+		{
+			name:       "red-eyes-ambiguous",
+			keyword:    "Red-Eyes",
+			wantErr:    "Error: Couldn't narrow down the cards to one.",
+			allowNoErr: true,
+		},
+		{
+			name:      "not-found",
+			keyword:   "NonExistentCardName12345",
+			wantErr:   "Error: Card not found.",
+			errStrict: true,
+		},
 	}
 
-	k = "Raigeki"
-	r, err = ygodb.Scraping(k, ygodb.LangEN)
-	e = ygodb.Card{
-		ID:        "4343",
-		Name:      "Raigeki",
-		Limited:   "",
-		Attribute: "SPELL",
-		Text:      "Destroy all monsters your opponent controls.",
-	}
-	// FIXME: Revert to t.Fatalf once the external API becomes stable.
-	if err != nil {
-		t.Skipf("when keyword %s error occurred %s\n", k, err.Error())
-	}
-	if r != e {
-		t.Fatalf("when keyword %s\nreturned %#v\nexpected %#v", k, r, e)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := ygodb.Scraping(tt.keyword, ygodb.LangEN)
 
-	k = "Red-Eyes"
-	r, err = ygodb.Scraping(k, ygodb.LangEN)
-	expectedError := "Error: Couldn't narrow down the cards to one."
-	if err == nil {
-		t.Logf("Expected error for keyword %s but got none. API may have changed.", k)
-	} else if err.Error() != expectedError {
-		t.Logf("when keyword %s returned %s, expected %s. API may have changed.", k, err.Error(), expectedError)
-	}
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Skipf("when keyword %s error occurred %s", tt.keyword, err.Error())
+				}
+				if r != tt.wantCard {
+					t.Fatalf("when keyword %s\nreturned %#v\nexpected %#v", tt.keyword, r, tt.wantCard)
+				}
+				return
+			}
 
-	// Test not found error
-	k = "NonExistentCardName12345"
-	_, err = ygodb.Scraping(k, ygodb.LangEN)
-	expectedError = "Error: Card not found."
-	if err == nil {
-		t.Fatalf("when keyword %s error not occurred\n", k)
-	}
-	if err.Error() != expectedError {
-		t.Logf("when keyword %s returned %s expected %s. Error format may have changed.", k, err.Error(), expectedError)
+			if err == nil {
+				if tt.allowNoErr {
+					t.Logf("Expected error for keyword %s but got none. API may have changed.", tt.keyword)
+					return
+				}
+				t.Fatalf("when keyword %s error not occurred", tt.keyword)
+			}
+
+			if err.Error() != tt.wantErr {
+				if tt.errStrict {
+					t.Fatalf("when keyword %s returned %s expected %s", tt.keyword, err.Error(), tt.wantErr)
+				}
+				t.Logf("when keyword %s returned %s, expected %s. API may have changed.", tt.keyword, err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 
 func Test_ExtractCardID(t *testing.T) {
-	s := "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=13049"
-	r := ygodb.ExtractCardID(s)
-	e := "13049"
-	if r != e {
-		t.Fatalf("when set %s, returned %s, expected %s", s, r, e)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "with-cid",
+			in:   "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=13049",
+			want: "13049",
+		},
+		{
+			name: "without-cid",
+			in:   "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1&sess=1&keyword=Gouki+Suprex&stype=1&ctype=&starfr=&starto=&pscalefr=&pscaleto=&linkmarkerfr=&linkmarkerto=&link_m=2&atkfr=&atkto=&deffr=&defto=&othercon=2&request_locale=en",
+			want: "",
+		},
 	}
 
-	s = "https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1&sess=1&keyword=Gouki+Suprex&stype=1&ctype=&starfr=&starto=&pscalefr=&pscaleto=&linkmarkerfr=&linkmarkerto=&link_m=2&atkfr=&atkto=&deffr=&defto=&othercon=2&request_locale=en"
-	r = ygodb.ExtractCardID(s)
-	e = ""
-	if r != e {
-		t.Fatalf("when set %s, returned %s, expected %s", s, r, e)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ygodb.ExtractCardID(tt.in)
+			if r != tt.want {
+				t.Fatalf("when set %s, returned %s, expected %s", tt.in, r, tt.want)
+			}
+		})
 	}
 }
 
 func Test_ExtractValue(t *testing.T) {
-	s := "ATK 3000"
-	r := ygodb.ExtractValue(s)
-	e := "3000"
-	if r != e {
-		t.Fatalf("when set %s, returned %s, expected %s", s, r, e)
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"atk", "ATK 3000", "3000"},
+		{"no-number", "DEF -", ""},
 	}
 
-	s = "DEF -"
-	r = ygodb.ExtractValue(s)
-	e = ""
-	if r != e {
-		t.Fatalf("when set %s, returned %s, expected %s", s, r, e)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ygodb.ExtractValue(tt.in)
+			if r != tt.want {
+				t.Fatalf("when set %s, returned %s, expected %s", tt.in, r, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request adds comprehensive unit tests for both the main application logic and internal functions of the `ygodb` package. These tests improve test coverage and help ensure correctness of key features, such as mode parsing, pretty list formatting, and HTML parsing utilities.

**New unit tests for application logic:**

* [`main_test.go`](diffhunk://#diff-79ce3229c13921b79b1175dcb211336aaf84dfd8edcf19c07698934d4fe70e5eR1-R123): Added tests for mode parsing and string conversion (`mode.String`, `atoMode`, `modes`), Markdown link formatting (`linkMD`), pretty list extraction and validation (`prettyList`, `isPrettyTarget`), and the `help` function.

**New unit tests for HTML parsing and utility functions:**

* [`packages/ygodb/ygodb_internal_test.go`](diffhunk://#diff-8a8de1d7b19ccd02a523fea0a05f455c8715f2c0495151ba905bb9054f4d4858R1-R107): Added tests for extracting card IDs and limited status from HTML (`extractID`, `extractLimited`), and for verifying base and API URL generation (`siteURL`, `apiURL`).