### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
 on: ["push"]
+permissions:
+  contents: read
 jobs:
   build:
     name: Go build


### PR DESCRIPTION
Potential fix for [https://github.com/kotaoue/ygoc/security/code-scanning/7](https://github.com/kotaoue/ygoc/security/code-scanning/7)

Add an explicit `permissions` block in `.github/workflows/build.yml` at the workflow root (right after `on:` is the cleanest place), so all jobs inherit least-privilege defaults unless overridden.

Best minimal fix without changing behavior:
- Add:
  - `contents: read` (required for checkout/read repo contents).
- Keep the rest unchanged.

If later a step fails due to missing scopes (e.g., checks/status updates), you can add only those specific permissions at job level, but the single best immediate fix for this finding is explicit minimal read permission at root.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
