### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,10 @@ name: "CodeScanning"
 on:
   push:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/kotaoue/ygoc/security/code-scanning/5](https://github.com/kotaoue/ygoc/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/codeql-analysis.yml` at the workflow root (recommended here since there is only one job).  
Best-practice minimal permissions for CodeQL analysis are:

- `contents: read` (for checkout/repository read access)
- `security-events: write` (required to upload CodeQL SARIF results)

This change does not alter workflow logic; it only scopes `GITHUB_TOKEN` permissions explicitly and safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
